### PR TITLE
fix for latest work width on team member page

### DIFF
--- a/app/styles/components/team-member/team-member.less
+++ b/app/styles/components/team-member/team-member.less
@@ -71,6 +71,7 @@
 .PageTeamMember [data-latest-work] {
   .Grid-cell {
     padding: 0;
+    display: block;
   }
 }
 


### PR DESCRIPTION
- fixed bug where latest work cards collapsed if there was only one on the page